### PR TITLE
More friendly error message if attribute values are not quoted

### DIFF
--- a/LuaXML_lib.c
+++ b/LuaXML_lib.c
@@ -671,10 +671,14 @@ int Xml_eval(lua_State *L) {
 				// parse tag header
 				size_t sepPos = find(token, "=", 0);
 				if (token[sepPos]) { // regular attribute (key="value")
-					const char *aVal = token + sepPos + 2;
-					lua_pushlstring(L, token, sepPos);
-					Xml_pushDecode(L, aVal, strlen(aVal) - 1);
-					lua_rawset(L, -3);
+					if (token[sepPos + 1] == '"' || token[sepPos + 1] == '\'') {
+						const char *aVal = token + sepPos + 2;
+						lua_pushlstring(L, token, sepPos);
+						Xml_pushDecode(L, aVal, strlen(aVal) - 1);
+						lua_rawset(L, -3);
+					} else {
+						luaL_error(L, "Malformed XML: attribute value not quoted in '%s'", token);
+					}
 				}
 			}
 			if (!token || (*token == ESC)) {

--- a/unittest.lua
+++ b/unittest.lua
@@ -93,6 +93,9 @@ function TestXml:test_basics()
 	lu.assertErrorMsgContains("file error or file not found",
 		xml.load, "invalid_filename")
 
+	-- malformed XML attribute
+	lu.assertErrorMsgContains("Malformed XML", xml.eval, "<a bad=0></a>")
+
 	-- safeguard against global namespace pollution
 	lu.assertNil(_G.xml)
 end


### PR DESCRIPTION
XML requires all attribute values to be quoted. If the input to `xml.eval` wrongly failed to quote an attribute value, LuaXML still omits the first and last bytes of the attribute value as if it was quoted, which can be very confusing.

(Please disregard what I wrote on the original version of this PR; that was based on the behavior of another fork of LuaXML. On this fork, using a non-quoted attribute value does not result in massive memory allocation, but the first and last bytes of the value are silently dropped.)